### PR TITLE
Change UI message handler to use timeout to fix I7-2240 

### DIFF
--- a/libchimara/chimara-glk.c
+++ b/libchimara/chimara-glk.c
@@ -1540,7 +1540,7 @@ chimara_glk_run(ChimaraGlk *self, const gchar *plugin, int argc, char *argv[], G
 	priv->ignore_next_arrange_event = FALSE;
 
 	/* Start listening for UI messages */
-	priv->ui_message_handler_id = gdk_threads_add_idle((GSourceFunc)chimara_glk_process_queue, self);
+	priv->ui_message_handler_id = gdk_threads_add_timeout(20, (GSourceFunc)chimara_glk_process_queue, self);
 
     /* Run in a separate thread */
 	g_clear_pointer(&priv->thread, g_thread_unref);


### PR DESCRIPTION
found the reason for high CPU load inside this loop. added the timeout to fix https://inform7.atlassian.net/browse/I7-2240?atlOrigin=eyJpIjoiNDU4MjM3MzYzODg4NGU3ZjhiMmZlOWMzNTkyYjYyNzkiLCJwIjoiaiJ9
@ptomato what do you think?